### PR TITLE
Add netlify.toml that always serves index.html

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
I've assumed this should be right for this a gatsby site?

Also it might be worth updating the netlify site to use this fork under the organization or alternatively moving the repo?

Just thought I'd note that point here 😁 