### PR TITLE
Removing height from timeline component

### DIFF
--- a/src/components/timeline/timeline.module.scss
+++ b/src/components/timeline/timeline.module.scss
@@ -13,7 +13,6 @@
 }
 
 .wrapper {
-    height: 300px;
     //background-color: red;
     overflow-x: auto;
     overflow-y: hidden;


### PR DESCRIPTION
The time in the timeline component can go off the bottom, or be covered up by a horizontal scroll bar.
Issue is because the height is currently fixed at 300px, which causes the issue when the content exceeds that height.

Removing the height solves the issue, and doesn't seem to introduce any new issues on the current site.

Noticeable on the deployed site for today's schedule:

* Firefox on Ubuntu:
![Screenshot from 2021-10-29 11-12-28](https://user-images.githubusercontent.com/22912854/139409352-127ee8f9-17c6-43ea-9f4b-4444edf2daf9.png)
* Chromium on Ubuntu:
![Screenshot from 2021-10-29 11-13-35](https://user-images.githubusercontent.com/22912854/139409477-79600992-171e-46ec-88e7-c93d7d8feccc.png)